### PR TITLE
fix: add homepage to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "playground",
   "version": "0.1.0",
-  "homepage": "https://open-rpc.github.io/playground/",
+  "homepage": "https://playground.open-rpc.org/",
   "dependencies": {
     "@babel/core": "7.2.2",
     "@babel/plugin-proposal-class-properties": "^7.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "playground",
   "version": "0.1.0",
-  "private": true,
+  "homepage": "https://open-rpc.github.io/playground/",
   "dependencies": {
     "@babel/core": "7.2.2",
     "@babel/plugin-proposal-class-properties": "^7.3.0",


### PR DESCRIPTION
webpack uses `homepage` as a base url. helps out `npm` as well.


here is the relevant code in our repo dealing with that:

https://github.com/open-rpc/playground/blob/b989ff610ee3bacffe26693fb5a3e5466d3f6c6a/config/paths.js#L24-L40





**NOTE**: this still lets you override the base url via `PUBLIC_PATH`. as you can see in the code it uses that first if available