### PR TITLE
feat: support Schema link in url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3447,6 +3447,11 @@
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         }
       }
     },
@@ -5597,6 +5602,11 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
           "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         }
       }
     },
@@ -11236,9 +11246,9 @@
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.6.0.tgz",
+      "integrity": "sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA=="
     },
     "querystring": {
       "version": "0.2.0",
@@ -11967,6 +11977,11 @@
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         },
         "tough-cookie": {
           "version": "2.4.3",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "postcss-loader": "3.0.0",
     "postcss-preset-env": "6.6.0",
     "postcss-safe-parser": "4.0.1",
+    "qs": "^6.6.0",
     "raw-loader": "^1.0.0",
     "react": "^16.8.1",
     "react-app-polyfill": "^0.2.1",

--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,8 @@ import './App.css'
 import fetchUrlSchemaFile from './fetchUrlSchemaFile';
 import fetchSchemaFromRpcDiscover from './fetchSchemaFromRpcDiscover';
 import AppBar from './AppBar/AppBar';
+import qs from 'qs'
+
 
 export default class App extends React.Component {
 
@@ -76,6 +78,10 @@ export default class App extends React.Component {
   }
 
   async componentDidMount() {
+    let urlParams = qs.parse(window.location.search, { ignoreQueryPrefix: true })
+    if (urlParams['schemaUrl']) {
+      this._handleUrlChange(urlParams['schemaUrl'])
+    }
     setTimeout(this.refreshEditorData, 1000);
   }
 


### PR DESCRIPTION
i went with parameter name`schemaUrl`. Using the variable name `url` for _part_ of the total url string inside the url string seemed confusing.

#### example
`http://localhost:3000/?schemaUrl=https://raw.githubusercontent.com/etclabscore/open-rpc-ethereum-js/zac1/openrpc.json`

