### PR TITLE
bug: fix html grid missing container warning

### DIFF
--- a/src/AppBar/AppBar.tsx
+++ b/src/AppBar/AppBar.tsx
@@ -64,7 +64,7 @@ class ApplicationBar extends Component<IProps> {
                 </Paper>
               </Grid>
             </Hidden>
-            <Grid item xs={6} sm={2} alignItems="flex-end">
+            <Grid item xs={6} sm={2} alignItems="flex-end" container>
               <FormControlLabel
                 style={{ marginLeft: "30px", height: "30px" }}
                 control={


### PR DESCRIPTION
One of the grid react components is missing container property.