### PR TITLE
chore(enable fork ci): add ci support for forked PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ aliases:
       only: master
   - &filter-only-semantic-pr
     branches:
-      only:  /^(dependabot|fix|feat)\/.*$/
+      only:  /^(pull|dependabot|fix|feat)\/.*$/
 
 defaults: &defaults
   working_directory: ~/playground


### PR DESCRIPTION
I think this should enable the forked PRs for playground. Prior to this the build step was restricted to things that passed the Semantic PR filter, I just added pull request to that list. It will still hold the build for an approved release.