### PR TITLE
fix: update pristine to use github issues template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -4,8 +4,6 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 This document is licensed under [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.html).
 
-When using the name 'version' we mean the versioning scheme described in [VERSIONING.md](VERSIONING.md)
-
 ## Introduction
 
 This document is to describe the functionality a project MUST provide in terms of creating build artifacts. It also describes the structure in which project's MUST write build artifacts in.
@@ -64,7 +62,7 @@ Each release target MUST have a `bin/build.{target}.{ext}` file.
 The result of this is that every project MUST produce a build for each target when the following command is invoked:
 
 ```
-bin/build.{target}.{ext}`
+bin/build.{target}.{ext}
 ```
 
 The file MUST be placed in the project's `bin` directory.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ For small documentation changes and fixes, these can be done quickly following t
 1. Review & Test changes
     * If the code changed, then test it. If documentation changed, then preview the rendered Markdown.
 2. Commiting
-    * Follow the [Convention Commits](CONVENTIONAL_COMMITS.md) guidelines to create a commit message
+    * Follow the [Conventional Commits](CONVENTIONAL_COMMITS.md) guidelines to create a commit message.
 3. Sign the CLA
     * Make sure you've signed the repository's Contributor License Agreement. We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction. We ask this of all contributors in order to assure our users of the origin and continuing existence of the code. You only need to sign the CLA once.
 4. Submit a pull request

--- a/README.md
+++ b/README.md
@@ -106,6 +106,6 @@ You can learn more in the [Create React App documentation](https://facebook.gith
 
 To learn React, check out the [React documentation](https://reactjs.org/).
 
-### Contributing
+##### Contribution Resources
 
 How to contribute, build and release are outlined in [CONTRIBUTING.md](CONTRIBUTING.md), [BUILDING.md](BUILDING.md) and [RELEASING.md](RELEASING.md) respectively. Commits in this repository follow the [CONVENTIONAL_COMMITS.md](CONVENTIONAL_COMMITS.md) specification.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,6 +18,15 @@ It is NOT the purpose of this document to describe how a project might create a 
 
 ## Release Pipeline
 
+Each Pristine project MUST provide a `bin/release.sh` script which will make a release to the various targets.
+
+Each target may be scripted directly into the `bin/release.sh` shell script, or it may be broken down into files following the pattern:`./bin/release.{target}.sh`.
+
+While the `.sh` extension is mandatory, the scripts may be written with one of the following headers:
+ - `#!bin/sh`
+ - `#!bin/node`
+ - `#!/usr/bin/env node`
+
 ### Create a build from current branch
 
 Process is outlined in [BUILDING.md](BUILDING.md)


### PR DESCRIPTION
fixes #409 

It would appear that github issues template didn't make it into playground when it was pristinified. This adds the issues template as well as any changes that have been made to pristine since it was added to this repo.