### PR TITLE
Add support for default values via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ If you require to have different default values for the `uiSchema`, `schemaUrl` 
 | REACT_APP_DEFAULT_UISCHEMA_METHODS_UI_METHODPLUGINS | Default value for `uiSchema[methods][ui:methodPlugins]` |
 | REACT_APP_DEFAULT_UISCHEMA_PARAMS_UI_DEFAULTEXPANDED | Default value for `uiSchema[params][ui:defaultExpanded]` |
 | REACT_APP_DEFAULT_SCHEMAURL | Default value for `schemaUrl` |
-| REACT_APP_EXAMPLE_DOCUMNETS_DROPDOWN_TITLE | Default title value for the examples drop-down |
-| REACT_APP_EXAMPLE_DOCUMNETS_DROPDOWN_TEXT | Default text value for the examples drop-down |
-| REACT_APP_EXAMPLE_DOCUMNETS_DROPDOWN_LIST | Default list of examples |
+| REACT_APP_EXAMPLE_DOCUMENTS_DROPDOWN_TITLE | Default title value for the examples drop-down |
+| REACT_APP_EXAMPLE_DOCUMENTS_DROPDOWN_TEXT | Default text value for the examples drop-down |
+| REACT_APP_EXAMPLE_DOCUMENTS_DROPDOWN_LIST | Default list of examples |
 
 *.env.development for a view only case*
 ```
@@ -104,9 +104,9 @@ REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_EXAMPLESDROPDOWN=true
 REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_EDIT=false
 REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_TRANSPORTS=false
 REACT_APP_DEFAULT_SCHEMAURL="https://raw.githubusercontent.com/open-rpc/examples/master/service-descriptions/petstore-openrpc.json"
-REACT_APP_EXAMPLE_DOCUMNETS_DROPDOWN_TITLE="Deployed Services"
-REACT_APP_EXAMPLE_DOCUMNETS_DROPDOWN_TEXT="Deployed Services"
-REACT_APP_EXAMPLE_DOCUMNETS_DROPDOWN_LIST=[{"name":"Pet Store","url":"https://raw.githubusercontent.com/open-rpc/examples/master/service-descriptions/petstore-openrpc.json"},{"name":"Shipping Service","url":"https://myserver.com/shipping/openrpc.json"},{"name":"Order Service","url":"https://myserver.com/order/openrpc.json"}]
+REACT_APP_EXAMPLE_DOCUMENTS_DROPDOWN_TITLE="Deployed Services"
+REACT_APP_EXAMPLE_DOCUMENTS_DROPDOWN_TEXT="Deployed Services"
+REACT_APP_EXAMPLE_DOCUMENTS_DROPDOWN_LIST=[{"name":"Pet Store","url":"https://raw.githubusercontent.com/open-rpc/examples/master/service-descriptions/petstore-openrpc.json"},{"name":"Shipping Service","url":"https://myserver.com/shipping/openrpc.json"},{"name":"Order Service","url":"https://myserver.com/order/openrpc.json"}]
 ```
 
 ## Resources and Inspirations

--- a/README.md
+++ b/README.md
@@ -46,10 +46,14 @@ examples:
 
 - set splitView to false
   - `http://playground.open-rpc.org/?uiSchema[appBar][ui:splitView]=false`
+- disable the appbar splitView
+  - `http://playground.open-rpc.org/?uiSchema[appBar][ui:edit]=false`
 - hide appbar input bar
   - `http://playground.open-rpc.org/?uiSchema[appBar][ui:input]=false`
 - hide appbar examples dropdown
   - `http://playground.open-rpc.org/?uiSchema[appBar][ui:examplesDropdown]=false`
+- hide appbar transports
+  - `http://playground.open-rpc.org/?uiSchema[appBar][ui:transports]=false`
 - provide custom name and logo
 - `http://playground.open-rpc.org/?uiSchema[appBar][ui:title]=My Site&uiSchema[appBar][ui:logoUrl]=https://github.com/open-rpc/design/raw/master/icons/open-rpc-logo-noText/open-rpc-logo-noText%20(PNG)/128x128.png`
 
@@ -64,6 +68,45 @@ https://playground.open-rpc.org/?schemaUrl=https://gist.githubusercontent.com/[g
 - use a _specific revision_ for a Gist file:
 ```
 https://playground.open-rpc.org/?schemaUrl=https://gist.githubusercontent.com/[gist username]/[gist ID]/raw/[gist commit ID]/[file name]
+```
+
+## Configuration via Environment Variables
+
+If you require to have different default values for the `uiSchema`, `schemaUrl` or some other labels in the page that are not part of the `uiSchema`, you can use the below environment variables in your desired `.env` files before starting the app or before building it:
+
+
+| Variable    | Description |
+| ----------- | ----------- |
+| REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_INPUT | Default value for `uiSchema[appBar][ui:input]` |
+| REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_INPUTPLACEHOLDER | Default value for `uiSchema[appBar][ui:inputPlaceholder]` |
+| REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_LOGOURL | Default value for `uiSchema[appBar][ui:logoUrl]` |
+| REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_SPLITVIEW | Default value for `uiSchema[appBar][ui:splitView]` |
+| REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_DARKMODE | Default value for `uiSchema[appBar][ui:darkMode]` |
+| REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_TITLE | Default value for `uiSchema[appBar][ui:title]` |
+| REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_EXAMPLESDROPDOWN | Default value for `uiSchema[appBar][ui:examplesDropdown]` |
+| REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_EDIT | Default value for `uiSchema[appBar][ui:edit]` |
+| REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_TRANSPORTS | Default value for `uiSchema[appBar][ui:transports]` |
+| REACT_APP_DEFAULT_UISCHEMA_METHODS_UI_DEFAULTEXPANDED | Default value for `uiSchema[methods][ui:defaultExpanded]` |
+| REACT_APP_DEFAULT_UISCHEMA_METHODS_UI_METHODPLUGINS | Default value for `uiSchema[methods][ui:methodPlugins]` |
+| REACT_APP_DEFAULT_UISCHEMA_PARAMS_UI_DEFAULTEXPANDED | Default value for `uiSchema[params][ui:defaultExpanded]` |
+| REACT_APP_DEFAULT_SCHEMAURL | Default value for `schemaUrl` |
+| REACT_APP_EXAMPLE_DOCUMNETS_DROPDOWN_TITLE | Default title value for the examples drop-down |
+| REACT_APP_EXAMPLE_DOCUMNETS_DROPDOWN_TEXT | Default text value for the examples drop-down |
+| REACT_APP_EXAMPLE_DOCUMNETS_DROPDOWN_LIST | Default list of examples |
+
+*.env.development for a view only case*
+```
+REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_INPUT=false
+REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_LOGOURL="https://www.shutterstock.com/image-vector/abstract-initial-letter-s-logo-260nw-1862762845.jpg"
+REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_SPLITVIEW=false
+REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_TITLE="Company Services"
+REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_EXAMPLESDROPDOWN=true
+REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_EDIT=false
+REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_TRANSPORTS=false
+REACT_APP_DEFAULT_SCHEMAURL="https://raw.githubusercontent.com/open-rpc/examples/master/service-descriptions/petstore-openrpc.json"
+REACT_APP_EXAMPLE_DOCUMNETS_DROPDOWN_TITLE="Deployed Services"
+REACT_APP_EXAMPLE_DOCUMNETS_DROPDOWN_TEXT="Deployed Services"
+REACT_APP_EXAMPLE_DOCUMNETS_DROPDOWN_LIST=[{"name":"Pet Store","url":"https://raw.githubusercontent.com/open-rpc/examples/master/service-descriptions/petstore-openrpc.json"},{"name":"Shipping Service","url":"https://myserver.com/shipping/openrpc.json"},{"name":"Order Service","url":"https://myserver.com/order/openrpc.json"}]
 ```
 
 ## Resources and Inspirations

--- a/src/AppBar/AppBar.tsx
+++ b/src/AppBar/AppBar.tsx
@@ -75,6 +75,7 @@ class ApplicationBar extends Component<IProps> {
             </Grid>
             <Hidden smDown>
               <Grid item container justify="center" alignItems="center" sm={8} >
+                {this.props.uiSchema && this.props.uiSchema.appBar && this.props.uiSchema.appBar["ui:transports"] &&
                 <Grid item>
                   <TransportDropdown
                     transports={this.props.transportList}
@@ -86,6 +87,7 @@ class ApplicationBar extends Component<IProps> {
                     }}
                   />
                 </Grid>
+                }
                 <Grid item sm={6}>
                   {this.props.uiSchema && this.props.uiSchema.appBar && this.props.uiSchema.appBar["ui:input"] &&
                     <Paper style={{
@@ -107,8 +109,10 @@ class ApplicationBar extends Component<IProps> {
                 }
               </Grid>
             </Hidden>
+
             <Grid item xs={6} sm={6} md={2} container justify="flex-end" alignItems="center">
-              {uiSchema && uiSchema.appBar["ui:splitView"] ?
+            {uiSchema && uiSchema.appBar["ui:edit"] ?
+              uiSchema && uiSchema.appBar["ui:splitView"] ?
                 <Tooltip title={"Full Screen"}>
                   <IconButton onClick={() => {
                     if (onSplitViewChange) {
@@ -128,7 +132,9 @@ class ApplicationBar extends Component<IProps> {
                     <EditIcon />
                   </IconButton>
                 </Tooltip>
-              }
+              :
+              ''
+            }
               <Tooltip title="Toggle Dark Theme">
                 <IconButton>
                   {uiSchema && uiSchema.appBar["ui:darkMode"] ?

--- a/src/ExampleDocumentsDropdown/ExampleDocumentsDropdown.tsx
+++ b/src/ExampleDocumentsDropdown/ExampleDocumentsDropdown.tsx
@@ -36,13 +36,17 @@ const ExampleDocumentsDropdown: React.FC<IProps> = ({ examples, onChange }) => {
 
   return (
     <>
-      <Tooltip title={"Example OpenRPC Documents"}>
+      <Tooltip title={process.env.REACT_APP_EXAMPLE_DOCUMNETS_DROPDOWN_TITLE ? 
+        process.env.REACT_APP_EXAMPLE_DOCUMNETS_DROPDOWN_TITLE : 
+        "Example OpenRPC Documents"}>
         <Button
           onClick={handleClick}
           variant="outlined"
           endIcon={<DropdownIcon />}
           style={{ height: "38px", fontSize: "11px", marginLeft: "10px" }}
-        >examples</Button>
+        >{process.env.REACT_APP_EXAMPLE_DOCUMNETS_DROPDOWN_TEXT ? 
+          process.env.REACT_APP_EXAMPLE_DOCUMNETS_DROPDOWN_TEXT : 
+          "examples"}</Button>
       </Tooltip>
       <Menu
         id="simple-menu"

--- a/src/ExampleDocumentsDropdown/ExampleDocumentsDropdown.tsx
+++ b/src/ExampleDocumentsDropdown/ExampleDocumentsDropdown.tsx
@@ -36,16 +36,16 @@ const ExampleDocumentsDropdown: React.FC<IProps> = ({ examples, onChange }) => {
 
   return (
     <>
-      <Tooltip title={process.env.REACT_APP_EXAMPLE_DOCUMNETS_DROPDOWN_TITLE ? 
-        process.env.REACT_APP_EXAMPLE_DOCUMNETS_DROPDOWN_TITLE : 
+      <Tooltip title={process.env.REACT_APP_EXAMPLE_DOCUMENTS_DROPDOWN_TITLE ? 
+        process.env.REACT_APP_EXAMPLE_DOCUMENTS_DROPDOWN_TITLE : 
         "Example OpenRPC Documents"}>
         <Button
           onClick={handleClick}
           variant="outlined"
           endIcon={<DropdownIcon />}
           style={{ height: "38px", fontSize: "11px", marginLeft: "10px" }}
-        >{process.env.REACT_APP_EXAMPLE_DOCUMNETS_DROPDOWN_TEXT ? 
-          process.env.REACT_APP_EXAMPLE_DOCUMNETS_DROPDOWN_TEXT : 
+        >{process.env.REACT_APP_EXAMPLE_DOCUMENTS_DROPDOWN_TEXT ? 
+          process.env.REACT_APP_EXAMPLE_DOCUMENTS_DROPDOWN_TEXT : 
           "examples"}</Button>
       </Tooltip>
       <Menu

--- a/src/UISchema.tsx
+++ b/src/UISchema.tsx
@@ -7,6 +7,8 @@ export interface IUISchema {
     ["ui:splitView"]: boolean,
     ["ui:darkMode"]: boolean,
     ["ui:examplesDropdown"]: boolean,
+    ["ui:edit"]: boolean,
+    ["ui:transports"]: boolean,
   };
   methods: {
     ["ui:defaultExpanded"]: boolean,

--- a/src/examplesList.tsx
+++ b/src/examplesList.tsx
@@ -29,8 +29,8 @@ let defaultExamples = [
   },
 ];
 
-if (process.env.REACT_APP_EXAMPLE_DOCUMNETS_DROPDOWN_LIST) {
-  defaultExamples = JSON.parse(process.env.REACT_APP_EXAMPLE_DOCUMNETS_DROPDOWN_LIST);
+if (process.env.REACT_APP_EXAMPLE_DOCUMENTS_DROPDOWN_LIST) {
+  defaultExamples = JSON.parse(process.env.REACT_APP_EXAMPLE_DOCUMENTS_DROPDOWN_LIST);
 }
 
 export default defaultExamples;

--- a/src/examplesList.tsx
+++ b/src/examplesList.tsx
@@ -1,4 +1,4 @@
-export default [
+let defaultExamples = [
   {
     name: "api-with-examples",
     url: "https://raw.githubusercontent.com/open-rpc/examples/master/service-descriptions/api-with-examples-openrpc.json", //tslint:disable-line
@@ -28,3 +28,9 @@ export default [
     url: "https://raw.githubusercontent.com/open-rpc/examples/master/service-descriptions/empty-openrpc.json", //tslint:disable-line
   },
 ];
+
+if (process.env.REACT_APP_EXAMPLE_DOCUMNETS_DROPDOWN_LIST) {
+  defaultExamples = JSON.parse(process.env.REACT_APP_EXAMPLE_DOCUMNETS_DROPDOWN_LIST);
+}
+
+export default defaultExamples;

--- a/src/stores/UISchemaStore.ts
+++ b/src/stores/UISchemaStore.ts
@@ -8,22 +8,48 @@ export default createStore(() => {
 
   const defaultUISchema = {
     appBar: {
-      "ui:input": true,
-      "ui:inputPlaceholder": "Enter OpenRPC Document Url or rpc.discover Endpoint",
+      "ui:input": process.env.REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_INPUT ? 
+        (process.env.REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_INPUT.toLowerCase() === "true") : 
+        true,
+      "ui:inputPlaceholder": process.env.REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_INPUTPLACEHOLDER ? 
+        process.env.REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_INPUTPLACEHOLDER : 
+        "Enter OpenRPC Document Url or rpc.discover Endpoint",
       /* tslint:disable */
-      "ui:logoUrl": "https://github.com/open-rpc/design/raw/master/icons/open-rpc-logo-noText/open-rpc-logo-noText%20(PNG)/128x128.png",
+      "ui:logoUrl": process.env.REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_LOGOURL ? 
+        process.env.REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_LOGOURL : 
+        "https://github.com/open-rpc/design/raw/master/icons/open-rpc-logo-noText/open-rpc-logo-noText%20(PNG)/128x128.png",
       /* tslint:enable */
-      "ui:splitView": true,
-      "ui:darkMode": false,
-      "ui:title": "Playground",
-      "ui:examplesDropdown": true,
+      "ui:splitView": process.env.REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_SPLITVIEW ? 
+        (process.env.REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_SPLITVIEW.toLowerCase() === "true") : 
+        true,
+      "ui:darkMode": process.env.REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_DARKMODE ? 
+        (process.env.REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_DARKMODE.toLowerCase() === "true") : 
+        false,
+      "ui:title": process.env.REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_TITLE ? 
+        process.env.REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_TITLE : 
+        "OpenRPC Definitions",
+      "ui:examplesDropdown": process.env.REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_EXAMPLESDROPDOWN ? 
+        (process.env.REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_EXAMPLESDROPDOWN.toLowerCase() === "true") : 
+        true,
+      "ui:edit": process.env.REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_EDIT ? 
+        (process.env.REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_EDIT.toLowerCase() === "true") : 
+        true,
+      "ui:transports": process.env.REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_TRANSPORTS ? 
+        (process.env.REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_TRANSPORTS.toLowerCase() === "true") : 
+        true,
     },
     methods: {
-      "ui:defaultExpanded": false,
-      "ui:methodPlugins": true,
+      "ui:defaultExpanded": process.env.REACT_APP_DEFAULT_UISCHEMA_METHODS_UI_DEFAULTEXPANDED ? 
+        (process.env.REACT_APP_DEFAULT_UISCHEMA_METHODS_UI_DEFAULTEXPANDED.toLowerCase() === "true") : 
+        false,
+      "ui:methodPlugins": process.env.REACT_APP_DEFAULT_UISCHEMA_METHODS_UI_METHODPLUGINS ? 
+        (process.env.REACT_APP_DEFAULT_UISCHEMA_METHODS_UI_METHODPLUGINS.toLowerCase() === "true") : 
+        true,
     },
     params: {
-      "ui:defaultExpanded": false,
+      "ui:defaultExpanded": process.env.REACT_APP_DEFAULT_UISCHEMA_PARAMS_UI_DEFAULTEXPANDED ? 
+        (process.env.REACT_APP_DEFAULT_UISCHEMA_PARAMS_UI_DEFAULTEXPANDED.toLowerCase() === "true") : 
+        false,
     },
   };
   return useUISchema(mergeUISchema(defaultUISchema, query.uiSchema));

--- a/src/stores/UISchemaStore.ts
+++ b/src/stores/UISchemaStore.ts
@@ -27,7 +27,7 @@ export default createStore(() => {
         false,
       "ui:title": process.env.REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_TITLE ? 
         process.env.REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_TITLE : 
-        "OpenRPC Definitions",
+        "Playground",
       "ui:examplesDropdown": process.env.REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_EXAMPLESDROPDOWN ? 
         (process.env.REACT_APP_DEFAULT_UISCHEMA_APPBAR_UI_EXAMPLESDROPDOWN.toLowerCase() === "true") : 
         true,

--- a/src/stores/searchBarStore.ts
+++ b/src/stores/searchBarStore.ts
@@ -5,5 +5,5 @@ import queryParamStore from "./queryParamsStore";
 export default createStore(() => {
   const [query] = queryParamStore();
 
-  return useSearchBar(query.schemaUrl || query.url);
+  return useSearchBar(query.schemaUrl || query.url || process.env.REACT_APP_DEFAULT_SCHEMAURL);
 });


### PR DESCRIPTION
Add support for default values at start / build time for `uiSchema`, `schemaUrl` or some other labels in the page that are not part of the `uiSchema`

This is useful for scenarios where you just need to publish some specs and allow people to view them and try them out.